### PR TITLE
Ignore git folder for npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,3 +20,4 @@ resources
 tscommand-*
 .tscache/
 docs-build/
+.git


### PR DESCRIPTION
otherwise you get this error on multiple npm installs:
```
npm ERR! path /opt/server/node_modules/blend-promise-utils
npm ERR! code EISGIT
npm ERR! git /opt/server/node_modules/blend-promise-utils: Appears to be a git repo or submodule.
npm ERR! git     /opt/server/node_modules/blend-promise-utils
npm ERR! git Refusing to remove it. Update manually,
npm ERR! git or move it out of the way first.
```