### PR TITLE
Ensure promises throwing errors in settleAll cannot throw unhandledRejections

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,12 +11,6 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
 
-    ts: {
-      default: {
-        tsconfig: true
-      }
-    },
-
     prettier: {
       options: {
         singleQuote: true,
@@ -32,6 +26,10 @@ module.exports = function(grunt) {
       test: {
         cmd: 'npm',
         args: ['run', 'testCode']
+      },
+      compile: {
+        cmd: 'npm',
+        args: ['run', 'prepare']
       }
     },
 
@@ -74,6 +72,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-force-task');
   grunt.loadNpmTasks('grunt-run');
 
-  grunt.registerTask('test', [ 'ts', 'run:test', 'prettier', 'tslint:src', 'tslint:test']);
+  grunt.registerTask('test', [ 'run:compile', 'run:test', 'prettier', 'tslint:src', 'tslint:test']);
   grunt.registerTask('default', ['force:test', 'watch']);
 };

--- a/src/map.ts
+++ b/src/map.ts
@@ -24,6 +24,11 @@ function asNumericKey(key: string): string | number {
  * guarantee that the iteratee functions will complete in order. However, the results array will be
  * in the same order as the original coll.
  *
+ * Note also - because of how the iteratee is applied, there is a slight possibility that if your
+ * input is an array of promises, they could be settled before the iteratee is applied - if they
+ * reject in this scenario, it would result in an unhandledRejection. As such, you should use
+ * settleAll to deal with arrays of promises, which will avoid this scenario.
+ *
  * @param {Array | Iterable | Object} input - A collection to iterate over.
  * @param {AsyncFunction} iteratee - An async function to apply to each item in coll. The iteratee
  *     should return the transformed item. Invoked with (item, key).

--- a/src/settleAll.ts
+++ b/src/settleAll.ts
@@ -1,4 +1,4 @@
-import { map } from './map';
+import { mapLimit } from './map';
 
 export interface SettledPromises<T, V> {
   errors: V[];
@@ -21,8 +21,9 @@ export async function settleAll<T, V>(
   // tslint:disable-next-line:no-any (no way to guarantee error typings)
   errFn: (err: any) => V = err => err,
 ): Promise<SettledPromises<T, V>> {
-  const intermediateResults: { errors?: V; results?: T }[] = await map(
+  const intermediateResults: { errors?: V; results?: T }[] = await mapLimit(
     promises,
+    promises.length,
     async (p: Promise<T>) => {
       try {
         return { results: await p };

--- a/src/settleAll.ts
+++ b/src/settleAll.ts
@@ -1,5 +1,3 @@
-import { mapLimit } from './map';
-
 export interface SettledPromises<T, V> {
   errors: V[];
   results: T[];
@@ -21,16 +19,14 @@ export async function settleAll<T, V>(
   // tslint:disable-next-line:no-any (no way to guarantee error typings)
   errFn: (err: any) => V = err => err,
 ): Promise<SettledPromises<T, V>> {
-  const intermediateResults: { errors?: V; results?: T }[] = await mapLimit(
-    promises,
-    promises.length,
-    async (p: Promise<T>) => {
+  const intermediateResults: { errors?: V; results?: T }[] = await Promise.all(
+    (promises || []).map(async p => {
       try {
         return { results: await p };
       } catch (err) {
         return { errors: errFn(err) };
       }
-    },
+    }),
   );
   const settledPromises: SettledPromises<T, V> = { results: [], errors: [] };
   for (const result of intermediateResults) {

--- a/test/settleAll.test.ts
+++ b/test/settleAll.test.ts
@@ -18,6 +18,14 @@ test('returns settled promise values in order when no errFn provided', async t =
   });
 });
 
+test('settles null value', async t => {
+  const res = await promiseUtils.settleAll(null as any);
+  t.deepEqual(res, {
+    errors: [],
+    results: [],
+  });
+});
+
 test('runs and returns result of errFn on failed promises', async t => {
   const testPromises: Promise<any>[] = [
     Promise.resolve('a'),


### PR DESCRIPTION
I ran into a situation where the mapLimit approach of settleAll would take too long to apply a handler to a function and would consequently result in an unhandledRejection. This was the only approach I found that could combat this issue. Unfortunately, I was also unable to create a minimal repro in the unit tests for this library, but this is the original code that caused the issue:
```
  await promiseUtils.settleAll(
    [
      fromCallback(cb => entityHistoryModel.removeEntityHistory(ctx, loanId, cb)),
      deletePropertyInfo(ctx, _.get(loan, 'application.propertyInfo._id')),
      fromCallback(cb => activityModel.removeByTarget(ctx, loanId, cb)),
      fromCallback(cb => asyncTaskResponseModel.remove(ctx, { loanId }, cb)),
      fromCallback(cb => disclosuresPackageModel.remove(ctx, { loanId }, cb)),
      fromCallback(cb => taskModel.removeByTopicId(ctx, loanId, cb)),
      fromCallback(cb => loanProcessModel.remove(ctx, { topicId: loanId }, {}, cb)),
      fromCallback(cb => loanRequestModel.remove(ctx, { loanId }, cb)),
      fromCallback(cb => loanApplicationTemplateModel.remove(ctx, { loanId }, cb)),
      fromCallback(cb => mortgageApplicationsModel.remove(ctx, { loanId }, cb)),
      moduleUpdateJobModel.remove(ctx, { loanId }),
      fromCallback(cb => notificationModel.remove(ctx, { loanId }, cb)),
      partyModel.remove(ctx, {
        topicId: loanId,
        type: { $nin: PartyTypes.BORROWER_TYPES },
      }),
      deleteDocumentsAndTrack(ctx, loanId),
      eSign.removeEnvelopes(ctx, { applicationId }),
      fromCallback(cb => loanDataService.purgeData(ctx, loanId, cb)),
      (async () => {
        if (loan.application.loanType === LoanTypes.ACCOUNT_OPENING) {
          await accountOpening.purgeByTopicId(ctx, loan._id);
        }
      })(),
    ],
    async err => diagnostics.error(ctx, err, { subsystem: 'purge' }),
  );
```
Likely there is some threshold for number of async control flows or something that is needed to reproduce.