### PR TITLE
Correct settleAll comment

### DIFF
--- a/src/settleAll.ts
+++ b/src/settleAll.ts
@@ -6,7 +6,7 @@ export interface SettledPromises<T, V> {
 /**
  * Attempts to settle all promises in promises in parallel, calling errFn when a promise rejects.
  * Similar to Promise.all, but does not fail fast. For resolved promises, the result array contains
- * resolved values in the same order as the promises. For rejected promises, the result array
+ * resolved values in the same order as the promises. For rejected promises, the error array
  * contains the return values of errFn in the same order as the promises.
  *
  * @param {Promise<T>[]} promises - An array of promises to attempt to settle.

--- a/src/settleAll.ts
+++ b/src/settleAll.ts
@@ -6,8 +6,8 @@ export interface SettledPromises<T, V> {
 /**
  * Attempts to settle all promises in promises in parallel, calling errFn when a promise rejects.
  * Similar to Promise.all, but does not fail fast. For resolved promises, the result array contains
- * the resolved value at the same index as the promise. For rejected promises, the result array
- * contains the return value of errFn at the same index as the promise.
+ * resolved values in the same order as the promises. For rejected promises, the result array
+ * contains the return values of errFn in the same order as the promises.
  *
  * @param {Promise<T>[]} promises - An array of promises to attempt to settle.
  * @param {Function} errFn - The function to call when a promise rejects.


### PR DESCRIPTION
Clarify that the results and errors will be returned in the same order as the promises from which they came from. Removes mentions of indices.