### PR TITLE
Fix handing of large sub-lists in flatMap

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -170,13 +170,13 @@ export async function flatMap(input: any, iteratee: any): Promise<any[]> {
   if (!input) {
     return [];
   }
-  const output = [];
+  let output: any[] = [];
   const nestedOutput = await map(input, iteratee);
   for (const partialOutput of nestedOutput) {
     // tslint:disable-next-line:no-any (could possibly be an array)
     if (partialOutput && (partialOutput as any).length !== undefined) {
       // tslint:disable-next-line:no-any (is definitely an array)
-      output.push(...(partialOutput as any));
+      output = output.concat(partialOutput);
     } else {
       output.push(partialOutput);
     }

--- a/test/flatMap.test.ts
+++ b/test/flatMap.test.ts
@@ -39,3 +39,8 @@ test('handles empty input group', async t => {
   const output = await promiseUtils.flatMap([], _.identity);
   t.deepEqual(output, []);
 });
+
+test('handles large sub-lists', async t => {
+  const output = await promiseUtils.flatMap(_.range(10), async () => _.range(1_000_000));
+  t.is(output.length, 10_000_000);
+});


### PR DESCRIPTION
Credit to @shawnjones253 for identifying the issue and provided a solution.

Major issue is with the large list handling in spread operator in node https://github.com/nodejs/node/issues/27732.

Without this fix, the test will result this
![Screen Shot 2022-07-01 at 4 03 23 PM](https://user-images.githubusercontent.com/22654024/176976422-2ffea8a4-553f-46e8-b9e1-3da96914283e.png)

A side note: lodash's `flatten` function has similar issue https://github.com/lodash/lodash/blob/master/.internal/baseFlatten.js#L28