### PR TITLE
fix for maximum stack size exceeded exception when flattening large arrays

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -170,13 +170,13 @@ export async function flatMap(input: any, iteratee: any): Promise<any[]> {
   if (!input) {
     return [];
   }
-  const output = [];
+  let output = [];
   const nestedOutput = await map(input, iteratee);
   for (const partialOutput of nestedOutput) {
     // tslint:disable-next-line:no-any (could possibly be an array)
     if (partialOutput && (partialOutput as any).length !== undefined) {
       // tslint:disable-next-line:no-any (is definitely an array)
-      output.push(...(partialOutput as any));
+      output = output.concat(partialOutput) as any[];
     } else {
       output.push(partialOutput);
     }

--- a/test/flatMap.test.ts
+++ b/test/flatMap.test.ts
@@ -39,3 +39,8 @@ test('handles empty input group', async t => {
   const output = await promiseUtils.flatMap([], _.identity);
   t.deepEqual(output, []);
 });
+
+test('handles large sub-lists', async t => {
+  const output = await promiseUtils.flatMap(_.range(10), async () => _.range(1_000_000));
+  t.is(output.length, 10_000_000);
+});


### PR DESCRIPTION
found a hint at how to fix this when reading https://github.com/nodejs/node/issues/27732

lodash appears to use similar code in `_.flatten`